### PR TITLE
Remove nested menu option

### DIFF
--- a/Select Parent Artboards.sketchplugin/Contents/Sketch/manifest.json
+++ b/Select Parent Artboards.sketchplugin/Contents/Sketch/manifest.json
@@ -10,6 +10,8 @@
     }
   ],
   "menu": {
+    "title" : "Select Parent Artboards",
+    "isRoot" : true,
     "items": [
       "selectParentArtboards"
     ]


### PR DESCRIPTION
This change removes the need to invoke the plugin from within a nested menu.
![remove-submenu](https://cloud.githubusercontent.com/assets/591670/20148378/4bcb7f92-a67a-11e6-85de-3cd42f3e6dcc.png)
